### PR TITLE
Don't require master versions of libraries.

### DIFF
--- a/lock.json
+++ b/lock.json
@@ -1,10 +1,10 @@
 {
-    "memo": "b5862bbc883a72ed4a87ba04a96707ef6c415edf1c7b99eac1d3fbb1fe5fc291",
+    "memo": "9f2b1b430f221bd4a5e94e48397ddffdfbd1bd59b7ba584afea798224690d75a",
     "projects": [
         {
             "name": "github.com/Sirupsen/logrus",
-            "branch": "master",
-            "revision": "3ec0642a7fb6488f65b06f9040adc67e3990296a",
+            "version": "v0.11.5",
+            "revision": "ba1b36c82c5e05c4f912a88eab0dcd91a171688f",
             "packages": [
                 "."
             ]
@@ -12,7 +12,7 @@
         {
             "name": "github.com/beorn7/perks",
             "branch": "master",
-            "revision": "b965b613227fddccbfffe13eae360ed3fa822f8d",
+            "revision": "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9",
             "packages": [
                 "quantile"
             ]
@@ -28,15 +28,15 @@
         {
             "name": "github.com/golang/protobuf",
             "branch": "master",
-            "revision": "c9c7427a2a70d2eb3bafa0ab2dc163e45f143317",
+            "revision": "2bba0603135d7d7f5cb73b2125beeda19c09f4ef",
             "packages": [
                 "proto"
             ]
         },
         {
             "name": "github.com/matttproud/golang_protobuf_extensions",
-            "branch": "master",
-            "revision": "fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a",
+            "version": "v1.0.0",
+            "revision": "3247c84500bff8d9fb6d579d800f20b3e091582c",
             "packages": [
                 "pbutil"
             ]
@@ -47,7 +47,8 @@
             "revision": "6edb48674bd9467b8e91fda004f2bd7202d60ce4",
             "packages": [
                 ".",
-                "ext"
+                "ext",
+                "log"
             ]
         },
         {
@@ -60,8 +61,8 @@
         },
         {
             "name": "github.com/prometheus/client_golang",
-            "branch": "master",
-            "revision": "7664178cb2d46b7b36a28d7b0af688ab436a3fa0",
+            "version": "v0.8.0",
+            "revision": "c5b7fccd204277076155f10851dad72b76a49317",
             "packages": [
                 "prometheus"
             ]
@@ -69,7 +70,7 @@
         {
             "name": "github.com/prometheus/client_model",
             "branch": "master",
-            "revision": "fa8ad6fec33561be4280a8f0514318c79d7f6cb6",
+            "revision": "6f3806018612930941127f2a7c6c453ba2c527d2",
             "packages": [
                 "go"
             ]
@@ -77,18 +78,20 @@
         {
             "name": "github.com/prometheus/common",
             "branch": "master",
-            "revision": "0d5de9d6d8629cb8bee6d4674da4127cd8b615a3",
+            "revision": "49fee292b27bfff7f354ee0f64e1bc4850462edf",
             "packages": [
                 "expfmt",
+                "internal/bitbucket.org/ww/goautoneg",
                 "model"
             ]
         },
         {
             "name": "github.com/prometheus/procfs",
             "branch": "master",
-            "revision": "c91d8eefde16bd047416409eb56353ea84a186e4",
+            "revision": "a1dba9ce8baed984a2495b658c82687f8157b98f",
             "packages": [
-                "."
+                ".",
+                "xfs"
             ]
         },
         {
@@ -110,7 +113,7 @@
         {
             "name": "golang.org/x/net",
             "branch": "master",
-            "revision": "4a1c855a052c2bad0e019ccfe8193a33d77adf5e",
+            "revision": "ffcf1bedda3b04ebb15a168a59800a73d6dc0f4d",
             "packages": [
                 "context"
             ]
@@ -118,7 +121,7 @@
         {
             "name": "golang.org/x/sys",
             "branch": "master",
-            "revision": "b699b7032584f0953262cb2788a0ca19bb494703",
+            "revision": "493114f68206f85e7e333beccfabc11e98cba8dd",
             "packages": [
                 "unix"
             ]

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,4 @@
 {
     "dependencies": {
-        "github.com/Sirupsen/logrus": {
-            "branch": "master"
-        },
-        "github.com/prometheus/client_golang": {
-            "branch": "master"
-        },
-        "golang.org/x/net": {
-            "branch": "master"
-        }
     }
 }


### PR DESCRIPTION
`dep` tries to transitively satisfy version constraints, and this makes it a lot harder...